### PR TITLE
Add pyyaml dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
           activate-environment: true
 
       - name: Smoke test uvx installation
-        run: uvx cubehandler --help
+        # uvx automatically installs the package in a dedicated environment,
+        # here we instruct it to build the package locally instead of downloading it from PyPI
+        run: uvx --from . cubehandler --help
 
       - name: Install package and its dependencies
         run: uv pip install -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
+          activate-environment: true
+
+      - name: Smoke test uvx installation
+        run: uvx cubehandler --help
 
       - name: Install package and its dependencies
-        run: python3 -m pip install -e .[dev]
+        run: uv pip install -e .[dev]
 
       - name: Run pytest
         run: pytest -v --cov --cov-report json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "ase",
     "scikit-image",
     "typer",
+    "pyyaml~=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I've used the same version constraint that is currently in aiida-core.

I also added a smoke test using `uvx` (pipx equivalent) that would have caught this issue.

On main, the following command fails

```console
$ uvx cubehandler --help
Traceback (most recent call last):
  File "/home/hollas/.local/share/uv/tools/cubehandler/bin/cubehandler", line 4, in <module>
    from cubehandler.cli.main import app
  File "/home/hollas/.local/share/uv/tools/cubehandler/lib64/python3.12/site-packages/cubehandler/cli/main.py", line 5, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Closes #28 