### PR TITLE
Reduce Python dependency to version 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "ase",
     "scikit-image",


### PR DESCRIPTION
I've been using Cubehandler under Python 3.9 and the compression functionality (at least through reduce_data_density_slicing) seems to work as expected. Would it be possible to reduce the required Python version?